### PR TITLE
Fix LICENSE file packaging

### DIFF
--- a/jfr-polyfill/build.gradle.kts
+++ b/jfr-polyfill/build.gradle.kts
@@ -102,6 +102,6 @@ signing {
 
 tasks.withType<Jar>().configureEach {
     into(".") {
-        from(rootProject.layout.projectDirectory.file("../LICENSE"))
+        from(rootProject.layout.projectDirectory.file("LICENSE"))
     }
 }


### PR DESCRIPTION
The reference to the LICENSE file was wrongly specified